### PR TITLE
Command Line Tool

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Usage:
 Python
 ~~~~~~~~
 
-::
+.. code-block:: python
 
     from gingerit.gingerit import GingerIt
 
@@ -38,9 +38,10 @@ Python
 Command Line
 ~~~~~~~~
 
-::
-    $ python gingerit.py [-h] -i INPUT [-o] [-f FILE] [-t {split,truncate}] [-v VERIFY]
+.. code-block:: sh
 
+  python gingerit.py [-h] -i INPUT [-o] [-f FILE] [-t {split,truncate}] [-v VERIFY]
+  
   -h, --help            show this help message and exit
   -i INPUT, --input INPUT
                         Input text or path to text file
@@ -52,9 +53,10 @@ Command Line
 
 A simple example is as follows:
 
-::
-    $ python gingerit.py -i "The smelt of fliwers bring back memories."
-    $ The smell of flowers brings back memories.
+.. code-block:: sh
+
+    python gingerit.py -i "The smelt of fliwers bring back memories."
+    The smell of flowers brings back memories.
 
 Thanks
 ------

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,9 @@ Installation:
 Usage:
 ------
 
+Python
+~~~~~~~~
+
 ::
 
     from gingerit.gingerit import GingerIt
@@ -32,11 +35,26 @@ Usage:
     parser = GingerIt()
     parser.parse(text)
 
-TODO:
------
+Command Line
+~~~~~~~~
 
-    - Commandline Tool
+::
+    $ python gingerit.py [-h] -i INPUT [-o] [-f FILE] [-t {split,truncate}] [-v VERIFY]
 
+  -h, --help            show this help message and exit
+  -i INPUT, --input INPUT
+                        Input text or path to text file
+  -o, --output          Print detailed output
+  -f FILE, --file FILE  Redirect to output file
+  -t {split,truncate}, --truncation {split,truncate}
+                        Truncation strategy if the text length exceeds 600 characters
+  -v VERIFY, --verify VERIFY
+
+A simple example is as follows:
+
+::
+    $ python gingerit.py -i "The smelt of fliwers bring back memories."
+    $ The smell of flowers brings back memories.
 
 Thanks
 ------

--- a/gingerit/gingerit.py
+++ b/gingerit/gingerit.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
+import re
+import json
 import requests
+import argparse
+from pathlib import Path
 
 URL = "https://services.gingersoftware.com/Ginger/correct/jsonSecured/GingerTheTextFull"  # noqa
 API_KEY = "6ae0c3a0-afdc-4532-a810-82ded0054236"
@@ -30,7 +34,7 @@ class GingerIt(object):
     @staticmethod
     def _change_char(original_text, from_position, to_position, change_with):
         return "{}{}{}".format(
-            original_text[:from_position], change_with, original_text[to_position + 1 :]
+            original_text[:from_position], change_with, original_text[to_position + 1:]
         )
 
     def _process_data(self, text, data):
@@ -48,10 +52,109 @@ class GingerIt(object):
                 corrections.append(
                     {
                         "start": start,
-                        "text": text[start : end + 1],
+                        "text": text[start: end + 1],
                         "correct": suggest.get("Text", None),
                         "definition": suggest.get("Definition", None),
                     }
                 )
 
         return {"text": text, "result": result, "corrections": corrections}
+
+
+def get_text_content(_input, truncation_strategy):
+    '''
+    Obtain text content from command line input or from a text file
+    '''
+    if Path(_input).is_file():
+        with open(_input, 'r') as f:
+            text = f.read()
+    else:
+        text = _input
+    text = text.strip()
+
+    text_length = len(text)
+    text_list = list()  # list of text chunks
+    delimiter_list = list()  # list of delimiters
+
+    if text_length > 600:
+        '''
+        Since the API call supports only 600 characters, we need to split the text. Truncation strategies are to either:
+        1. Split the text into multiple chunks
+        2. Truncate the text to 600 characters
+        '''
+        if truncation_strategy == 'truncate':
+            # use only the first 600 characters
+            text_list.append(text[:600])
+            delimiter_list.append('')
+
+        elif truncation_strategy == 'split':
+            '''
+            Split the text into multiple chunks and store the delimiters.
+            Obtain paragraphs from the text. If a paragraph is too big, split it into multiple sentences.
+            '''
+            paragraphs = text.split('\n')
+            for paragraph in paragraphs:
+                paragraph = paragraph.strip()
+                if len(paragraph) > 600:
+                    # split on sentence boundaries
+                    sentences = re.split(r'[.?!]+', paragraph)
+                    sentence_delimiters = re.findall(
+                        r'[.?!]+', paragraph)  # store sentence delimiters
+                    for sentence, delimiter in zip(sentences, sentence_delimiters):
+                        sentence = sentence.strip()
+                        if sentence:
+                            text_list.append(sentence)
+                            delimiter_list.append(delimiter)
+                else:
+                    text_list.append(paragraph)
+                    delimiter_list.append('\n')
+    else:
+        text_list.append(text)
+        delimiter_list.append('')
+
+    return text_list, delimiter_list
+
+
+def main():
+    G = GingerIt()
+    parser = argparse.ArgumentParser(description='Gingerit CLI')
+    parser.add_argument(
+        '-i', '--input', help='Input text or path to text file', required=True)
+    parser.add_argument('-o', '--output', help='Print detailed output',
+                        default=False, action='store_true')
+    parser.add_argument(
+        '-f', '--file', help='Redirect to output file', default=None)
+    parser.add_argument('-t', '--truncation', help='Truncation strategy if the text length exceeds 600 characters',
+                        default='split', choices=['split', 'truncate'])
+    parser.add_argument('-v', '--verify', default=True)
+    args = parser.parse_args()
+
+    text_list, delimiter_list = get_text_content(
+        args.input, args.truncation)   # get all text chunks
+    corrections = list()
+    corrected_text = str()
+    for text, delimiter in zip(text_list, delimiter_list):
+        gingerit_parsed_output = G.parse(text)
+        # store all correction dictionaries returned by API
+        corrections.append(gingerit_parsed_output)
+        # get corrected text chunk
+        gingerit_parsed_correction = gingerit_parsed_output['result']
+        # append current corrected text chunk to the complete corrected text along with the delimiter
+        corrected_text = f"{corrected_text}{gingerit_parsed_correction}{delimiter} "
+
+    if args.output:
+        _output = corrections   # print detailed output
+    else:
+        _output = corrected_text    # print corrected text only
+
+    if args.file is not None:   # redirect to output file
+        if isinstance(_output, list):   # if detailed output is a list, convert it to a string
+            _output = json.dumps(_output, indent=4)
+        with open(args.file, 'w') as f:
+            f.write(_output)
+    else:
+        print(_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/gingerit/gingerit.py
+++ b/gingerit/gingerit.py
@@ -65,10 +65,14 @@ def get_text_content(_input, truncation_strategy):
     '''
     Obtain text content from command line input or from a text file
     '''
-    if Path(_input).is_file():
-        with open(_input, 'r') as f:
-            text = f.read()
-    else:
+    try:
+        if Path(_input).is_file():
+            with open(_input, 'r') as f:
+                text = f.read()
+        else:
+            text = _input
+    except OSError:
+        # if the input text is too long, it cannot be a file and will throw an OSError
         text = _input
     text = text.strip()
 

--- a/tests/test_gingerit_cli.py
+++ b/tests/test_gingerit_cli.py
@@ -1,0 +1,94 @@
+import json
+import pytest
+import subprocess
+
+@pytest.fixture
+def run():
+    def run_cli_test(*args):
+        command = ["python gingerit/gingerit.py"] + list(args)
+        command = " ".join(command)
+        output = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE).stdout.read().decode().strip()
+        return output
+    return run_cli_test
+
+
+@pytest.mark.parametrize(
+    "text,expected,corrections",
+    [
+        (
+            "The smelt of fliwers bring back memories.",
+            "The smell of flowers brings back memories.",
+            [
+                {
+                    "start": 21,
+                    "definition": None,
+                    "correct": "brings",
+                    "text": "bring",
+                },
+                {
+                    "start": 13,
+                    "definition": "a plant cultivated for its blooms or blossoms",
+                    "correct": "flowers",
+                    "text": "fliwers",
+                },
+                {"start": 4, "definition": None, "correct": "smell", "text": "smelt"},
+            ],
+        ),
+        (
+            "Edwards will be sck yesterday",
+            "Edwards was sick yesterday",
+            [
+                {
+                    "start": 16,
+                    "definition": "affected by an impairment of normal physical or mental function",
+                    "correct": "sick",
+                    "text": "sck",
+                },
+                {"start": 8, "definition": None, "correct": "was", "text": "will be"},
+            ],
+        ),
+        ("Edwards was sick yesterday.", "Edwards was sick yesterday.", []),
+        ("", "", []),
+        (
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin vitae felis sed felis convallis egestas vel ornare massa. Fusce vehicula odio at sem pharetra condimentum. Pellentesque mattis tincidunt bibendum. Integer ultrices odio lorem. Sed venenatis turpis a commodo malesuada. Nunc bibendum tincidunt sem in sodales. Suspendisse non ligula ac ligula venenatis imperdiet eu ut ex. Fusce aliquet, ligula et tristique dignissim, nisi lorem accumsan libero, in porttitor velit erat et tortor. Fusce at libero aliquam, porttitor ligula quis, pellentesque leo. Fusce vitae diam ac quam suscipit pharetra vel hendrerit nisi. Curabitur eu magna sit amet enim porta lacinia. In hac habitasse platea proin.",
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin vitae felis sed felis convallis egestas vel ornare massa. Fusce vehicula odio at sem pharetra condimentum. Pellentesque mattis tincidunt bibendum. Integer ultrices odio Lorem. Sed venenatis turpis a commodo malesuada. Nunc bibendum tincidunt sem in sandals. Suspendisse non ligula ac ligula venenatis imperdiet eu ut ex. Fusce aliquet, ligula et tristique dignissim, nisi lorem accumsan libero, in porttitor velit erat et tortor. Fusce at libero aliquam, porttitor ligula quis, pellentesque leo. Fusce vitae diam Ac qualm suscipit porter",
+            [
+                {
+                "start": 593,
+                "text": "pharetr",
+                "correct": "porter",
+                "definition": "a person employed to carry luggage and supplies"
+            },
+            {
+                "start": 579,
+                "text": "quam",
+                "correct": "qualm",
+                "definition": "uneasiness about the fitness of an action"
+            },
+            {
+                "start": 576,
+                "text": "ac",
+                "correct": "Ac",
+                "definition": "a radioactive element of the actinide series; found in uranium ores"
+            },
+            {
+                "start": 312,
+                "text": "sodales",
+                "correct": "sandals",
+                "definition": "a shoe consisting of a sole fastened by straps to the foot"
+            },
+            {
+                "start": 232,
+                "text": "lorem",
+                "correct": "Lorem",
+                "definition": None
+            }
+            ]
+        )
+    ],
+)
+
+
+def test_gingerit_cli(text, expected, corrections, run):
+    assert run("-t truncate", "-i", f"'{text}'") == expected
+    assert eval(run("-o", "-t truncate", "-i", f"'{text}'"))[0]['corrections'] == corrections


### PR DESCRIPTION
Added command-line tool. Can be invoked using `python gingerit.py` and takes in the following arguments:
```sh
usage: python gingerit.py [-h] -i INPUT [-o] [-f FILE] [-t {split,truncate}] [-v VERIFY]

Gingerit CLI

optional arguments:
  -h, --help            show this help message and exit
  -i INPUT, --input INPUT
                        Input text or path to text file
  -o, --output          Print detailed output
  -f FILE, --file FILE  Redirect to output file
  -t {split,truncate}, --truncation {split,truncate}
                        Truncation strategy if the text length exceeds 600 characters
  -v VERIFY, --verify VERIFY
```

It also handles issue #18 of the text being too long in length by splitting the text into chunks and then recombining it. 

A test for the CLI has been included in `tests/test_gingerit_cli.py`.