### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 ---
 name: Tests
+permissions:
+  contents: read
+  secrets: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Azd325/gingerit/security/code-scanning/3](https://github.com/Azd325/gingerit/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `secrets: read` for accessing secrets like `GINGER_IT_API_KEY` and `CODECOV_TOKEN`.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
